### PR TITLE
Fixing capitalization error in PlayFabAdmin.js

### DIFF
--- a/PlayFabSdk/PlayFabAdmin.js
+++ b/PlayFabSdk/PlayFabAdmin.js
@@ -1,6 +1,6 @@
 var PlayFab = require("./PlayFab.js");
 
-exports.Settings = PlayFab.Settings;
+exports.settings = PlayFab.settings;
 
 exports.GetUserAccountInfo = function (request, callback) {
     if (PlayFab.settings.developerSecretKey == null) throw "Must have PlayFab.settings.DeveloperSecretKey set to call this method";


### PR DESCRIPTION
We were running into errors with PlayFabAdmin.Settings. It's grabbing the settings object from PlayFab, but it looks like it was grabbing Settings instead of settings.