### PR TITLE
Content-Length, Post Requests, and Emoji

### DIFF
--- a/PlayFabSdk/Scripts/PlayFab/PlayFab.js
+++ b/PlayFabSdk/Scripts/PlayFab/PlayFab.js
@@ -35,7 +35,7 @@ exports.GetServerUrl = function () {
 exports.MakeRequest = function (urlStr, request, authType, authValue, callback) {
     if (request == null)
         request = {};
-    var requestBody = JSON.stringify(request);
+    var requestBody = Buffer.from(JSON.stringify(request), 'utf8');
 
     var options = url.parse(urlStr);
     if (options.protocol !== "https:")


### PR DESCRIPTION
Hi -

It looks like the Node SDK doesn't handle long utf8 characters correctly when it's posting to the server. The https module ends up encoding into utf8, but the Content-Length was set using the string's length. When including emoji in the request (because who doesn't want an airplane in their username!), the content length will be too short, and the server will report that the string was unterminated. To replicate, using the Admin SDK:

PlayFabAdmin.UpdateUserTitleDisplayName({     
  PlayFabId: "85A8979D97D576B8",     
  DisplayName: "i love beets🕵🏻♀️💩"})

You'll get the following error:

{"code":400,
"status":"BadRequest",
"error":"InvalidRequest",
"errorCode":1071,
"errorMessage":"Invalid JSON in request",
"errorHash":"d863310ed6e31a73160eaa8939e9c3c9",
"errorDetails":{"ValidationError":["Unterminated string passed in. (62): {\"PlayFabId\":\"85A8979D97D576B8\",\"DisplayName\":\"dbeets🕵🏻"]}} 

This small change, to pre-encode the request as a Buffer with the utf8 encoding, will produce the correct length when uploading, and allow the request to succeed.

Cheers
-Courtland
