### PR TITLE
NodeSDK MakeRequest fix for React

### DIFF
--- a/PlayFabSdk/Scripts/PlayFab/PlayFab.js
+++ b/PlayFabSdk/Scripts/PlayFab/PlayFab.js
@@ -36,11 +36,7 @@ exports.GetServerUrl = function () {
 exports.MakeRequest = function (urlStr, request, authType, authValue, callback) {
     if (request == null)
         request = {};
-    var requestBody = null;
-    if (Number(process.version.match(/^v(\d+\.\d+)/)[1]) >= 4.7)
-        requestBody = Buffer.from(JSON.stringify(request), "utf8");
-    else
-        requestBody = JSON.stringify(request);
+    var requestBody = Buffer.from(JSON.stringify(request), "utf8");
 
     var options = url.parse(urlStr);
     if (options.protocol !== "https:")


### PR DESCRIPTION
When attempting to use the PlayFab NodeSDK with a React project,
there is a check in `PlayFab.js` that relies on `process.version` to
ensure that Node is >= v4.7.  However, this value is overwritten and
is a blank string with react-scripts.

As Node.js 4.X is now at end of life, I think this check is no longer necessary.

By removing this check I was able to get the MakeRequest function to work
properly.

I'm not a Node.js expert, any feedback is appreciated.