### PR TITLE
Add ForgetAllCredentials() to delete local session ticket from client

### DIFF
--- a/PlayFabSdk/Scripts/PlayFab/PlayFabClient.js
+++ b/PlayFabSdk/Scripts/PlayFab/PlayFabClient.js
@@ -2855,6 +2855,6 @@ exports.WriteTitleEvent = function (request, callback) {
 };
 
 exports.ForgetAllCredentials = function () {
-    PlayFab._internalSettings.sessionTicket == null;
+    PlayFab._internalSettings.sessionTicket = null;
 }
 

--- a/PlayFabSdk/Scripts/PlayFab/PlayFabClient.js
+++ b/PlayFabSdk/Scripts/PlayFab/PlayFabClient.js
@@ -2854,3 +2854,7 @@ exports.WriteTitleEvent = function (request, callback) {
     );
 };
 
+exports.ForgetAllCredentials = function () {
+    PlayFab._internalSettings.sessionTicket == null;
+}
+

--- a/PlayFabSdk/Scripts/typings/PlayFab/PlayFabClient.d.ts
+++ b/PlayFabSdk/Scripts/typings/PlayFab/PlayFabClient.d.ts
@@ -1075,7 +1075,9 @@ declare module PlayFabClientModule {
             request: PlayFabClientModels.WriteTitleEventRequest | null,
             callback: PlayFabModule.ApiCallback<PlayFabClientModels.WriteEventResponse> | null,
         ): void;
-
+        // Deletes the internally stored SessionTicket.
+        ForgetAllCredentials() : void;
+        
     }
 }
 


### PR DESCRIPTION
Addresses #115. Essentially equivalent to [`ForgetAllCredentials()`](https://github.com/PlayFab/CSharpSDK/blob/1ca5d4a2354b4bd3f5429047513562910c3fad19/PlayFabSDK/source/PlayFabAuthenticationContext.cs#L64) in the C# SDK.

Comments, edits, and suggestions are welcome.