### PR TITLE
Fixing typing issue with ApiCallback where error or result might be null

### DIFF
--- a/PlayFabSdk/Scripts/typings/PlayFab/PlayFab.d.ts
+++ b/PlayFabSdk/Scripts/typings/PlayFab/PlayFab.d.ts
@@ -27,6 +27,6 @@ declare module PlayFabModule {
     export interface IPlayFabResultCommon extends IPlayFabError {}
 
     export interface ApiCallback<TResult extends IPlayFabResultCommon> {
-        (error: IPlayFabError, result: IPlayFabSuccessContainer<TResult>): void;
+        (error: IPlayFabError | null, result: IPlayFabSuccessContainer<TResult> | null): void;
     }
 }


### PR DESCRIPTION
From [PlayFabSdk/Scripts/PlayFab/PlayFab.js](https://github.com/PlayFab/NodeSDK/blob/d1de74dfd8211a099814ba538a02f578382400aa/PlayFabSdk/Scripts/PlayFab/PlayFab.js#L105):
```
if (replyEnvelope.hasOwnProperty("error") || !replyEnvelope.hasOwnProperty("data")) {
    callback(replyEnvelope, null);
} else {
    callback(null, replyEnvelope);
}
```